### PR TITLE
ルートのタグが2つ以上でも対応出来るように修正

### DIFF
--- a/src/test/groovy/Tmp.groovy
+++ b/src/test/groovy/Tmp.groovy
@@ -76,7 +76,11 @@ class Tmp {
             } else {
                 def tmpParentTag = lastTag.getParent()
                 while (true) {
-                    if (indentCount > tmpParentTag.getIndentCount()) {
+                    // 親タグを持たなかった場合
+                    if (tmpParentTag == null) {
+                        tags.add(tag)
+                        break
+                    } else if (indentCount > tmpParentTag.getIndentCount()) {
                         tag.setParent(tmpParentTag)
                         tmpParentTag.getChildren().add(tag)
                         break


### PR DESCRIPTION
以下のようなケース

```
html
  head
body
  div
.
.

```
